### PR TITLE
Fix to run the app in Codespaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,9 @@ This project is a copy of the https://github.com/spring-projects/spring-petclini
 
 Spring Petclinic is a [Spring Boot](https://spring.io/guides/gs/spring-boot) application built using [Maven](https://spring.io/guides/gs/maven/) or [Gradle](https://spring.io/guides/gs/gradle/). You can build a jar file and run it from the command line (it should work just as well with Java 17 or newer):
 
+> [!WARNING]  
+> If you are using Codespaces for this exercise please run `sudo chmod -R 777 /home/vscode/.m2` before you execute the following commands.
+
 ```bash
 git clone https://github.com/github-copilot-workshop/copilot-petclinic.git
 cd copilot-petclinic


### PR DESCRIPTION
This pull request includes a minor change to the `readme.md` file. The change adds a warning message for users who are using Codespaces for the exercise, instructing them to run a specific command before executing the following commands.